### PR TITLE
Update VAN Key Name

### DIFF
--- a/docs/spoke-admin/van_list_loading.md
+++ b/docs/spoke-admin/van_list_loading.md
@@ -13,7 +13,7 @@ Set up VAN for Spoke integration
 1. You will need the application name and API key from
 VAN.
 
-**Accepted:** With the Ranks-,
+**Accepted:** Politics Rewired-,
 Hustle-, or Civis-type VAN API keys.
 
 **Not Accepted:** Spoke- type


### PR DESCRIPTION
This should still say Politics Rewired since we haven't needed to create our own VAN key type yet. Going to go ahead and commit this since it may be confusing to readers!